### PR TITLE
feat: Enable concurrent summarization via direct Google API calls

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -61,8 +61,8 @@
 
                 <table>
 
-                    <tr title="The connection profile to use for summaries. Note that choosing a different profile will require temporarily switching to the profile during summarization, discarding any unsaved changes to the current profile.">
-                        <td><span>Connection Profile</span></td>
+                    <tr title="Select the base SillyTavern Connection Profile for Google API. This profile's instructions and model settings will be used. The actual API key will be overridden by the keys below.">
+                        <td><span>Base Connection Profile</span></td>
                         <td><select id="connection_profile" class="text_pole"></select></td>
                     </tr>
 
@@ -87,8 +87,8 @@
 
                 <!-- API Key Management -->
                 <h4 class="textAlignCenter">API Key Management <i class="fa-solid fa-info-circle" title="Manage API keys for external services."></i></h4>
-                <label for="api_keys_input">Paste your API keys below, one per line:</label>
-                <textarea id="api_keys_input" class="text_pole" rows="4" placeholder="Enter API keys here..."></textarea>
+                <label for="api_keys_input">Enter raw Google API keys below, one per line. These will override the API key of the selected base Google profile above and be rotated:</label>
+                <textarea id="api_keys_input" class="text_pole" rows="4" placeholder="Enter raw Google API keys here, one per line..." title="Enter raw Google API keys, one per line. These will override the API key of the selected base Google profile above, and be rotated for each summarization."></textarea>
 
                 <hr>
 


### PR DESCRIPTION
This feature allows you to summarize multiple messages concurrently by providing a list of raw Google API keys. The extension makes direct calls to the Google AI API (Gemini-Pro) using these keys.

Key Changes:

1.  **UI for Raw API Keys:**
    *   I added a textarea in `settings.html` for you to input raw Google API keys, one per line.
    *   I fixed UI newline parsing to correctly handle multi-line input into an array of keys.
    *   I clarified UI labels:
        *   "Base Connection Profile": Selects an ST profile for instructions and model parameters.
        *   "Raw Google API Keys": For the list of keys to rotate.

2.  **Direct Google API Call Implementation:**
    *   I added `summarize_with_google_api` function to make `fetch` requests to `generativelanguage.googleapis.com` (Gemini-Pro).
    *   I construct JSON payloads, including prompts (message + instructions from base ST profile) and generation parameters (extracted from base ST profile if possible).
    *   I handle API responses and errors, including network issues and safety blocks.

3.  **Concurrent Summarization Logic:**
    *   I refactored `summarize_messages`:
        *   If raw Google API keys are provided, it launches concurrent calls to `summarize_with_google_api` using `Promise.allSettled`.
        *   I manage a `MAX_CONCURRENT_CALLS` limit and process messages in batches.
        *   I extract instructions and generation parameters from the selected "Base Connection Profile" to use with the direct Google API calls.
    *   **Fallback Mechanism:** If no raw API keys are entered, the system falls back to using the selected "Base Connection Profile" with SillyTavern's standard `generateRaw` function for sequential summarization.

4.  **Enhanced Error Handling:**
    *   I improved error detection and reporting for both direct API calls and fallback ST profile summarization.
    *   I ensured that SillyTavern's original connection profile and preset are always restored using a `try...finally` block in `summarize_messages`.
    *   UI updates to display specific error messages for affected messages.

5.  **Investigation Conclusion:** I determined that direct API key override for ST's native generation functions (like `generateRaw`) is not feasible, leading to the direct `fetch` approach for the multi-key concurrency feature.